### PR TITLE
Add travis.yml file w/ codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+go:
+  - 1.7
+script:
+  - go test -race -coverprofile=coverage.txt -covermode=atomic
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/response_test.go
+++ b/response_test.go
@@ -100,7 +100,7 @@ func (suite *ResponseTestSuite) TestJsonRenderFailure() {
 		recover()
 	}()
 	resp := response.New()
-	resp.SetResult(http.StatusOK, make(map[int]int))
+	resp.SetResult(http.StatusOK, func() {})
 	resp.Output()
 	suite.T().Error("JsonRenderer should fail with content that can not be serialized to JSON")
 }


### PR DESCRIPTION
Also update json render failure to use a function instead of a map of
ints.  json.Marshal now doesn't throw an error as of golang 1.7, but
returns an object:
https://golang.org/doc/go1.7#encoding_json